### PR TITLE
Fix warning due to no THREADS option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,10 @@ TARGET=simv
 #
 # ========================================================
 
+# Set the number of threads to use for parallel compilation (2 * cores)
+CORES = $(shell getconf _NPROCESSORS_ONLN)
+THREADS = $(shell echo $$((2 * $(CORES))))
+
 VCSFLAGS= -full64 -sverilog -debug_all +warn=all -j$(THREADS) \
 					-timescale=1ns/1ps +v2k
 VCSFLAGS_GUI= -full64 -sverilog -debug_all +warn=all -j$(THREADS) \


### PR DESCRIPTION
Add back the CORES and THREADS calculation that is missing in this version of the Makefile.

Without the variables, `-j$(THREADS)` evaluates to `-j` and vcs thinks that we are trying to set `-j` to `-timescale=1ns/1ps`, which is invalid and throws warnings.